### PR TITLE
feat(populate-municipio): cria script para popular e predizer dados de um múnicipio

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "commit": "cz",
     "populate": "ts-node-transpile-only scripts/populate-database.ts",
     "populate-parto": "ts-node-transpile-only scripts/populate-partos.ts ",
+    "populate-municipio": "ts-node-transpile-only scripts/populate-municipio.ts ",
     "process": "ts-node-transpile-only scripts/process-municipio.ts "
   },
   "dependencies": {

--- a/scripts/populate-municipio.ts
+++ b/scripts/populate-municipio.ts
@@ -1,0 +1,18 @@
+import consola from 'consola';
+import { populatePartos } from './populate-partos';
+import { processing } from './process-municipio';
+
+
+export async function populateAndProcess(args: string[]) {
+  const municipio = args[0];
+  const csv = args[1];
+  await populatePartos(csv);
+
+  await processing([municipio, 'normal']);
+  await processing([municipio, 'cesaria']);
+  await processing([municipio, 'total']);
+
+
+
+
+} if (require.main === module) populateAndProcess(process.argv.slice(2));

--- a/scripts/populate-partos.ts
+++ b/scripts/populate-partos.ts
@@ -10,46 +10,50 @@ import { parse } from 'csv-parse';
 
 
 
-export async function test(csv: string) {
-  consola.log('Creating prisma client...')
-  const prisma = new PrismaClient();
-  await prisma.$connect()
-  let rows: any[] = [];
-  consola.log('Reading...')
-  fs.createReadStream(csv)
-    .pipe(parse({ delimiter: ',', from_line: 2 }))
-    .on('data', (row) => {
-      rows.push(row);
-    })
-    .on('error', (error) => {
-      consola.error(error)
-    })
-    .on('end', async () => {
-      consola.log('Inserting in database...')
-      for (let row of rows) {
-        await prisma.parto.upsert({
-          where: {
-            id: {
+export function populatePartos(csv: string) {
+  return new Promise<void>(async (resolve, reject) => {
+
+    consola.log('Creating prisma client...')
+    const prisma = new PrismaClient();
+    let rows: any[] = [];
+    consola.log('Reading...')
+    fs.createReadStream(csv)
+      .pipe(parse({ delimiter: ',', from_line: 2 }))
+      .on('data', (row) => {
+        rows.push(row);
+      })
+      .on('error', (error) => {
+        consola.error(error)
+      })
+      .on('end', async () => {
+        consola.log('Inserting in database...')
+        for (let row of rows) {
+          await prisma.parto.upsert({
+            where: {
+              id: {
+                ano: parseInt(row[0]),
+                mes: parseInt(row[1]),
+                municipio_id: parseInt(row[5])
+              }
+            },
+            update: {},
+            create: {
               ano: parseInt(row[0]),
               mes: parseInt(row[1]),
+              parto_normais: parseInt(row[2]),
+              parto_cesaria: parseInt(row[3]),
+              parto_total: parseInt(row[4]),
               municipio_id: parseInt(row[5])
             }
-          },
-          update: {},
-          create: {
-            ano: parseInt(row[0]),
-            mes: parseInt(row[1]),
-            parto_normais: parseInt(row[2]),
-            parto_cesaria: parseInt(row[3]),
-            parto_total: parseInt(row[4]),
-            municipio_id: parseInt(row[5])
-          }
-        });
-      }
-      console.log('Inserted all')
-    })
+          });
+        }
+        resolve()
+        console.log('Inserted all')
+      })
 
-  // await prisma.$disconnect();
+    await prisma.$disconnect();
+  })
+
 }
 
-if (require.main === module) test(process.argv.slice(2)[0])
+if (require.main === module) populatePartos(process.argv.slice(2)[0])


### PR DESCRIPTION
Cria um script para adicionar os dados de um csv para o banco de dados e também faz a predição dos 3 tipos de partos diferentes. Também modifica os scripts de predição de um município (`process-municipio`) e popular os partos(`populate-partos`) para que funcionem de maneira correta nesse novo script.

resolves #23